### PR TITLE
fix: specify registry and avoid warning message

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ runs:
     # Configure Docker access to the Container Registry
     - run: |
         if [[ -z "$GCP_SERVICE_ACCOUNT_KEY" ]]; then
-          gcloud --quiet auth configure-docker
+          gcloud --quiet auth configure-docker gcr.io
         else
           echo "$GCP_SERVICE_ACCOUNT_KEY" | docker login --username _json_key --password-stdin gcr.io
         fi


### PR DESCRIPTION
Fix warning received

> WARNING: A long list of credential helpers may cause delays running 'docker build'. We recommend passing the registry name to configure only the registry you are using.